### PR TITLE
ci: test tfdocs gh-action patch

### DIFF
--- a/.github/workflows/auto-docs.yml
+++ b/.github/workflows/auto-docs.yml
@@ -25,7 +25,8 @@ jobs:
         ref: ${{ github.event.pull_request.head.ref }}
 
     - name: Render terraform docs inside the README.md
-      uses: terraform-docs/gh-actions@v0.10.0
+      # uses: terraform-docs/gh-actions@v0.10.0
+      uses: hansohn/gh-actions@fix_block_delim
       with:
         args: "--lockfile=false" 
         git-commit-message: "docs(readme): automated action"


### PR DESCRIPTION
## what
* test terraform-docs gh-action patch to remove extra - from block delim

## why
* terraform-docs and gh-action are using 2 different block delims and need to be aligned for implementation
